### PR TITLE
Removed objectAssign

### DIFF
--- a/src/callback-names.js
+++ b/src/callback-names.js
@@ -1,5 +1,3 @@
-import objectAssign from 'object-assign'
-
 export const thenable = [
     'onCancel',
     'onPasteReceived',
@@ -34,6 +32,6 @@ export const traditional = [
     'onValidateBatch'
 ]
 
-export const s3 = objectAssign([], traditional, [
+export const s3 = traditional.concat([
     'onCredentialsExpired'
 ])


### PR DESCRIPTION
Using `Object.assign` on objects with shared keys will overwrite the left object's properties with counterparts on the right. In this case, using it on an array means that shared indexes are overwritten. In this case, `onAutoRetry` is no longer available when using the S3 wrapper.

e.g.
```javascript
Object.assign([], [100, 101, 102], [200, 201]); // result: [200, 201, 102]
```

I've replaced it with `Array.concat`
```javascript
[100, 101, 102].concat([200, 201]); // result: [100, 101, 102, 200, 201]
```